### PR TITLE
Corrections to Polish translation

### DIFF
--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -21,7 +21,7 @@
     <string name="pref_show_found" comment="Title of show found geocaches in Filter category in add-on settings.">Pokaż znalezione</string>
     <string name="pref_show_found_summary" comment="Summary of show found geocaches in Filter category in add-on settings.">Pokaż znalezione skrzynki</string>
     <string name="pref_show_own" comment="Title of show own hidden (hidden by you) geocaches in Filter category in add-on settings.">Pokazuj własne ukryte</string>
-    <string name="pref_show_own_summary" comment="Summary of show own hidden (hidden by you) geocaches in Filter category in add-on settings.">Pokazuj własne skrytki (ukryte przez ciebie)</string>
+    <string name="pref_show_own_summary" comment="Summary of show own hidden (hidden by you) geocaches in Filter category in add-on settings.">Pokazuj własne skrzynki (ukryte przez ciebie)</string>
     <string name="menu_select_all" comment="ActionBar/Toolbar action button title for selecting all checkable items. Placed in geocache type and container size filter.">Zaznacz wszystko</string>
     <string name="menu_deselect_all" comment="ActionBar/Toolbar action button title for selecting none (deselecting all) checkable items. Placed in geocache type and container size filter.">Odznacz wszystko</string>
     <string name="progress_update_geocache" comment="Progress dialog message for updating single geocache.">Aktualizowanie skrzynki…</string>
@@ -29,7 +29,7 @@
     <string name="pref_logs_count_summary" comment="Summary of count of logs to be downloaded with geocachce choose setting in Downloading section in add-on settings.">Ilość wpisów do pobrania wraz ze skrzynką</string>
     <string name="button_gps" comment="Title of button which try to retrieve current coordinates from GPS/WiFi. Button is placed in search nearest screen.">GPS</string>
     <string name="pref_show_disabled" comment="Title of show disabled geocaches in Filter category in add-on settings.">Pokazuj nieaktywne</string>
-    <string name="pref_show_disabled_summary" comment="Summary of show disabled geocaches in Filter category in add-on settings.">Pokazuj tymczasowo niedostępne skrytki</string>
+    <string name="pref_show_disabled_summary" comment="Summary of show disabled geocaches in Filter category in add-on settings.">Pokazuj tymczasowo niedostępne skrzynki</string>
     <string name="progress_download_geocache" comment="Progress dialog message when you try download/import geocaches to Locus Map.">Pobieranie skrzynki…</string>
     <string name="pref_version" comment="Title of Application version in About section in add-on settings.">Wersja</string>
     <string name="pref_website" comment="Title of setting item which open web browser with Geocaching4Locus website. This placed in About section in add-on settings.">Strona WWW, forum, itp.</string>
@@ -89,29 +89,29 @@
     <string name="title_premium_member_warning" comment="Title of Premium member error/warning dialog">Dostęp użytkownika \"premium\"</string>
     <string name="error_basic_member_full_geocaching_quota_exceeded" comment="Error dialog message when basic member reach limit of full geocache details per day. The '%1$s' is replaced with count of full detail geocache limit (eg. '3 geocaches'), '%2$s' with period length (eg. '24 hours'), '%3$s' with time when quota will be fulfilled/reset (eg. '09:10').">Osiągnąłeś limit pobierania szczegółów skrzynek <b>%1$s co każde %2$s</b>. Twój dzienny limit zostanie odnowiony o %3$s.<br/>
 <br/>
-<i>Wykup konto "premium", aby codziennie móc pobrać szczegóły 6000 skrzynek oraz uzyskać dodatkowe korzyści. Odwiedź  stronę Geocaching.com już teraz.</i></string>
+<i>Wykup konto "premium", aby codziennie móc pobrać szczegóły 6000 skrzynek oraz uzyskać dodatkowe korzyści. Odwiedź stronę Geocaching.com już teraz.</i></string>
     <string name="error_premium_member_full_geocaching_quota_exceeded" comment="Error dialog message when premium member reach limit of full 6000 geocache details per day. The '%3$s' is replaced with time when quota will be fulfilled/reset (eg. '09:10').">Osiągnąłeś limit pobierania szczegółów skrzynek <b>%1$s co każde %2$s</b>. Twój dzienny limit zostanie odnowiony o %3$s.</string>
     <string name="title_method_quota_exceeded" comment="Title of error dialog when user reach the call limit per minute for Geocaching API call.">Hej, zwolnij!</string>
     <string name="error_method_quota_exceeded" comment="Message of error dialog when user reach the call limit per minute for Geocaching API call.">Osiągnąłeś minutowy limit maksymalnej ilości akcji/połączeń.</string>
     <plurals name="plurals_geocache" comment="Plurals for geocache. The '%d' is replaced with numeric value of geocache">
         <item quantity="one">%d skrzynka</item>
         <item quantity="few">%d skrzynki</item>
-        <item quantity="many">%d skrzynki</item>
-        <item quantity="other">%d skrzynki</item>
+        <item quantity="many">%d skrzynek</item>
+        <item quantity="other">%d skrzynek</item>
     </plurals>
     <plurals name="plurals_hour" comment="Plurals for hour. The '%d' is replaced with numeric value of hour">
         <item quantity="one">%d godzina</item>
         <item quantity="few">%d godziny</item>
-        <item quantity="many">%d godziny</item>
-        <item quantity="other">%d godziny</item>
+        <item quantity="many">%d godzin</item>
+        <item quantity="other">%d godzin</item>
     </plurals>
     <plurals name="plurals_minute" comment="Plurals for minute. The '%d' is replaced with numeric value of minute">
         <item quantity="one">%d minuta</item>
         <item quantity="few">%d minuty</item>
-        <item quantity="many">%d minuty</item>
-        <item quantity="other">%d minuty</item>
+        <item quantity="many">%d minut</item>
+        <item quantity="other">%d minut</item>
     </plurals>
-    <string name="pref_geocaching_live" comment="Title of 'Powered by Geocaching Live' item in Account settings. Clicking on this open WebBrowser with info about Geocaching Live API.">Oparte na silniku Geocaching Live .</string>
+    <string name="pref_geocaching_live" comment="Title of 'Powered by Geocaching Live' item in Account settings. Clicking on this open WebBrowser with info about Geocaching Live API.">Oparte na silniku Geocaching Live.</string>
     <string name="pref_geocaching_live_message" comment="Summary of 'Powered by Geocaching Live' item in Account settings.">Ten dodatek wykorzystuje silnik Geocaching Live do pobierania informacji o skrzynkach geocache. Kliknij tutaj, aby dowiedzieć się więcej…</string>
     <string name="error_invalid_api_response" comment="Error message when Geocaching Live API returns unexpected response.">Usługa Geocaching Live zwraca niewłaściwą odpowiedź:<br/>%s</string>
     <string name="notify_live_map" comment="Live map notification title. This title is used only for Android 6 and lower.">Geocaching4Locus mapa \"na żywo\"</string>
@@ -130,8 +130,8 @@
     <string name="launcher_download_logs" comment="Share button item title in geocache detail in Locus Map, which download 100 log items for selected geocache.">Pobierz wpisy</string>
     <string name="pref_download_logs_update_geocache" comment="Title of checkbox preference in Downloading settings. If is checked, the Update logs action in POI detail screen in Locus Map will also update listing and all other geocache detail together with logs. Unchecked to update only logs.">Aktualizacja skrzynki przy pobieraniu wpisów</string>
     <string name="pref_download_logs_update_geocache_summary" comment="Summary of checkbox preference in Downloading settings. If is checked, the Update logs action in POI detail screen in Locus Map will also update listing and all other geocache detail together with logs. Unchecked to update only logs.">Akcja \"Pobierz wpisy\" równocześnie aktualizuje skrzynkę geocache</string>
-    <string name="pref_step_geocaching_count" comment="Title of selectbox preference in Downloading settings.">Rozmiar pakietu pobierania skrytek</string>
-    <string name="pref_step_geocaching_count_summary" comment="Summary of selectbox preference in Downloading settings.">Okno dialogowe zmiany rozmiaru pakietu pobierania skrytek</string>
+    <string name="pref_step_geocaching_count" comment="Title of selectbox preference in Downloading settings.">Rozmiar pakietu pobierania skrzynek</string>
+    <string name="pref_step_geocaching_count_summary" comment="Summary of selectbox preference in Downloading settings.">Okno dialogowe zmiany rozmiaru pakietu pobierania skrzynek</string>
     <string name="error_premium_filter" comment="Error message when user who PM account have expired use PM account filters which cause errors on Geocaching Live API server side.">Niektóre filtry wymagają konta \"premium\", którego nie posiadasz. Aplikacja zostanie przełączona w tryb dla standardowych użytkowników. Proszę spróbuj ponownie.</string>
     <string name="pref_account" comment="Title of preference category for Account settings.">Konto</string>
     <string name="pref_filter" comment="Title of preference category for Filter settings.">Filtr</string>
@@ -152,18 +152,18 @@
     <string name="error_premium_feature" comment="Error dialog message when user with basic membership  wants to use feature for premium membership users.">Ta funkcja jest tylko dla użytkowników premium, przepraszam.</string>
     <string name="title_locus_map_error" comment="Error dialog title when Locus Map error occurs.">Błąd Locus Map</string>
     <string name="button_send_error_report" comment="Button for Send error report action.">Wyślij raport o błędach</string>
-    <string name="toast_error_report_sent" comment="Toast message showed after the user click on 'Send error report' button in error dialog.">Dziękujemy za wysłanie błąd.</string>
+    <string name="toast_error_report_sent" comment="Toast message showed after the user click on 'Send error report' button in error dialog.">Dziękujemy za zgłoszenie błędu.</string>
     <string name="error_continue_locus_map" comment="Dialog error message which is shown after the download error occurred. It's displayed only in case when some data was successfully received before this error.">Czy chcesz kontynuować częściowo odebranych danych do Locus Map?</string>
     <string name="button_yes" comment="Dialog button for Yes action.">Tak</string>
     <string name="button_no" comment="Dialog button for No action.">Nie</string>
     <string name="warning_basic_member" comment="Warning dialog message which is shown after the basic user is signed in.">Ten dodatek działa w pełni jedynie z kontami typu premium. Posiadając standardowe konto możesz pobrać skrzynki typów tradycyjna, event i CITO tylko wraz z podstawowymi informacjami (brak opisu, brak podpowiedzi, brak atrybutów, brak obrazów, brak wpisów itp.) oraz wykorzystywać je tylko z kilkoma filtrami wyszukiwania. Więcej informacji jest dostępnych w instrukcji użytkownika zamieszczonej na stronie Geocaching4Locus.</string>
     <string name="button_show_users_guide" comment="Dialog button which start WebBrowser with Geocaching4Locus User's guide web page.">Pokaż podręcznik użytkownika</string>
-    <string name="warning_external_storage_permission" comment="Warning message which is shown before request for write external storage permission.">Ta aplikacja potrzebuje <b>uprawnienia zapis na zewnętrznym magazynie danych</b> w celu przechowywania danych skrzynek dla Locus Map. Proszę <b>zezwolić</b> na dodanie tych uprawnień w kolejnym oknie dialogowym.</string>
+    <string name="warning_external_storage_permission" comment="Warning message which is shown before request for write external storage permission.">Ta aplikacja potrzebuje <b>uprawnienia do zapisywania na zewnętrznym magazynie danych</b> w celu przechowywania danych skrzynek dla Locus Map. Proszę <b>zezwolić</b> na dodanie tych uprawnień w kolejnym oknie dialogowym.</string>
     <string name="error_no_external_storage_permission" comment="Error message when app doesn't have write external storage permission.">Ta aplikacji nie posiada uprawnień <b>zapis na zewnętrznym magazynie danych</b>. To uprawnienie jest potrzebne, aby przechowywać dane dla Locus Map. </string>
-    <string name="pref_hide_geocaches_on_disabled" comment="Title of checkbox preference in Live Map settings. Marking this checkbox will cause to hides all Live Map geocaches in Locus Map after Live Map feature is disabled.">Ukrywaj skrzynki kiedy wyłączona</string>
-    <string name="pref_hide_geocaches_on_disabled_summary" content="Summary of checkbox preference in Live Map settings. Marking this checkbox will cause to hides all Live Map geocaches in Locus Map after Live Map feature is disabled.">Ukrywaj skrzynki , kiedy funkcja mapa na żywo jest wyłączona</string>
+    <string name="pref_hide_geocaches_on_disabled" comment="Title of checkbox preference in Live Map settings. Marking this checkbox will cause to hides all Live Map geocaches in Locus Map after Live Map feature is disabled.">Ukrywaj skrzynki, kiedy wyłączona</string>
+    <string name="pref_hide_geocaches_on_disabled_summary" content="Summary of checkbox preference in Live Map settings. Marking this checkbox will cause to hides all Live Map geocaches in Locus Map after Live Map feature is disabled.">Ukrywaj skrzynki, kiedy funkcja mapa na żywo jest wyłączona</string>
     <string name="pref_disable_dnf_nm_na_geocaches" comment="Title of checkbox preference in Downloading settings. Marking this checkbox will cause to mark geocache as not available with more Did Not Fond, Needs Maintenance or Need Archived logs.">Wyłącz skrzynki DNF, NM i NA</string>
-    <string name="pref_disable_dnf_nm_na_geocaches_summary" comment="Summary of checkbox preference in Downloading settings. Marking this checkbox will cause to mark geocache as not available with more Did Not Fond, Needs Maintenance or Need Archived logs.">Oznaczaj srzynkę jako niedostępną kiedy zawiera więcej wpisów <i>Nie znalazłem</i>, <i>Potrzebny serwis</i> lub <i>Potrzebna archiwizacja</i></string>
+    <string name="pref_disable_dnf_nm_na_geocaches_summary" comment="Summary of checkbox preference in Downloading settings. Marking this checkbox will cause to mark geocache as not available with more Did Not Fond, Needs Maintenance or Need Archived logs.">Oznaczaj skrzynkę jako niedostępną kiedy zawiera więcej wpisów <i>Nie znalazłem</i>, <i>Potrzebny serwis</i> lub <i>Potrzebna archiwizacja</i></string>
     <string name="pref_disable_dnf_nm_na_geocaches_logs_count" comment="Title of slider preference in Downloading settings. There can be selected how many Did Not Fond, Needs Maintenance or Need Archived logs (1 to 5) cause to mark geocache as not available.">Ile ostatnich wpisów sprawdzić</string>
     <string name="launcher_watch_geocache" comment="Share button item title in geocache detail in Locus Map, which add geocache to watch list.">Obserwuj skrzynkę</string>
     <string name="launcher_bookmark_geocache" comment="Share button item title in geocache detail in Locus Map, which add geocache to bookmark list.">Zakładka skrzynki</string>


### PR DESCRIPTION
Correct various minor errors and change some words to better reflect their meaning and to maintain consistency in naming.